### PR TITLE
Add promo code management interface

### DIFF
--- a/bot/database/methods/update.py
+++ b/bot/database/methods/update.py
@@ -1,4 +1,4 @@
-from bot.database.models import User, ItemValues, Goods, Categories
+from bot.database.models import User, ItemValues, Goods, Categories, PromoCode
 from bot.database import Database
 
 
@@ -51,4 +51,17 @@ def update_category(category_name: str, new_name: str) -> None:
         values={Goods.category_name: new_name})
     Database().session.query(Categories).filter(Categories.name == category_name).update(
         values={Categories.name: new_name})
+    Database().session.commit()
+
+
+def update_promocode(code: str, discount: int | None = None, expires_at: str | None = None) -> None:
+    """Update promo code discount or expiry date."""
+    values = {}
+    if discount is not None:
+        values[PromoCode.discount] = discount
+    if expires_at is not None or expires_at is None:
+        values[PromoCode.expires_at] = expires_at
+    if not values:
+        return
+    Database().session.query(PromoCode).filter(PromoCode.code == code).update(values=values)
     Database().session.commit()

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -589,7 +589,7 @@ async def confirm_buy_callback_handler(call: CallbackQuery):
     )
 
 async def apply_promo_callback_handler(call: CallbackQuery):
-    item_name = call.data[len('promo_'):]
+    item_name = call.data[len('applypromo_'):]
     bot, user_id = await get_bot_user_ids(call)
     lang = get_user_language(user_id) or 'en'
     TgConfig.STATE[user_id] = 'wait_promo'
@@ -1174,7 +1174,7 @@ def register_user_handlers(dp: Dispatcher):
     dp.register_callback_query_handler(confirm_buy_callback_handler,
                                        lambda c: c.data.startswith('confirm_'))
     dp.register_callback_query_handler(apply_promo_callback_handler,
-                                       lambda c: c.data.startswith('promo_'))
+                                       lambda c: c.data.startswith('applypromo_'))
     dp.register_callback_query_handler(buy_item_callback_handler,
                                        lambda c: c.data.startswith('buy_'))
     dp.register_callback_query_handler(pay_yoomoney,

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -142,7 +142,7 @@ def console() -> InlineKeyboardMarkup:
 def confirm_purchase_menu(item_name: str, lang: str) -> InlineKeyboardMarkup:
     inline_keyboard = [
         [InlineKeyboardButton(t(lang, 'purchase_button'), callback_data=f'buy_{item_name}')],
-        [InlineKeyboardButton(t(lang, 'apply_promo'), callback_data=f'promo_{item_name}')],
+        [InlineKeyboardButton(t(lang, 'apply_promo'), callback_data=f'applypromo_{item_name}')],
         [InlineKeyboardButton('🔙 Back to menu', callback_data='back_to_menu')]
     ]
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
@@ -232,7 +232,40 @@ def promo_codes_management() -> InlineKeyboardMarkup:
     inline_keyboard = [
         [InlineKeyboardButton('➕ Create promo code', callback_data='create_promo')],
         [InlineKeyboardButton('🗑️ Delete promo code', callback_data='delete_promo')],
+        [InlineKeyboardButton('🛠 Manage promo code', callback_data='manage_promo')],
         [InlineKeyboardButton('🔙 Go back', callback_data='shop_management')],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def promo_expiry_keyboard(back_data: str) -> InlineKeyboardMarkup:
+    """Keyboard to choose promo code expiry units."""
+    inline_keyboard = [
+        [InlineKeyboardButton('Days', callback_data='promo_expiry_days')],
+        [InlineKeyboardButton('Weeks', callback_data='promo_expiry_weeks')],
+        [InlineKeyboardButton('Months', callback_data='promo_expiry_months')],
+        [InlineKeyboardButton('No expiry', callback_data='promo_expiry_none')],
+        [InlineKeyboardButton('🔙 Go back', callback_data=back_data)],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def promo_codes_list(codes: list[str], action: str, back_data: str) -> InlineKeyboardMarkup:
+    """Create a list of promo codes with callback prefix."""
+    markup = InlineKeyboardMarkup()
+    for code in codes:
+        markup.add(InlineKeyboardButton(code, callback_data=f'{action}_{code}'))
+    markup.add(InlineKeyboardButton('🔙 Go back', callback_data=back_data))
+    return markup
+
+
+def promo_manage_actions(code: str) -> InlineKeyboardMarkup:
+    """Keyboard with actions for a single promo code."""
+    inline_keyboard = [
+        [InlineKeyboardButton('✏️ Change discount', callback_data=f'promo_manage_discount_{code}')],
+        [InlineKeyboardButton('⏰ Change expiry', callback_data=f'promo_manage_expiry_{code}')],
+        [InlineKeyboardButton('🗑️ Delete', callback_data=f'promo_manage_delete_{code}')],
+        [InlineKeyboardButton('🔙 Go back', callback_data='manage_promo')],
     ]
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 


### PR DESCRIPTION
## Summary
- extend admin promo code menu with create, delete, and manage options
- support expiry selection via days/weeks/months and update existing codes
- implement database method for updating promo codes
- fix promo code creation by renaming user apply promo callbacks to avoid conflicts

## Testing
- `python -m py_compile bot/handlers/user/main.py bot/keyboards/inline.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a637adc6388332a6325ac8edb4e8cb